### PR TITLE
Fix spelling from RateLimitUti to RateLimitUtil

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -1518,7 +1518,7 @@ app.get("/", ctx -> {
 });
 
 // you can overwrite the key-function:
-RateLimitUti.keyFunction = ctx -> // uses (ip+method+endpointPath) by default
+RateLimitUtil.keyFunction = ctx -> // uses (ip+method+endpointPath) by default
 {% endcapture %}
 {% capture kotlin %}
 app.get("/") { ctx ->
@@ -1527,7 +1527,7 @@ app.get("/") { ctx ->
 }
 
 // you can overwrite the key-function:
-RateLimitUti.keyFunction = { ctx -> } // uses (ip+method+endpointPath) by default
+RateLimitUtil.keyFunction = { ctx -> } // uses (ip+method+endpointPath) by default
 {% endcapture %}
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}
 


### PR DESCRIPTION
`RateLimitUtil` is spelled as `RateLimitUti` in the [FAQ > Rate Limiting](https://javalin.io/documentation#rate-limiting) section of the docs. 

Thanks to the contributors and maintainers :)