### PR TITLE
Add missing symbols to status code error mapping

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -970,7 +970,7 @@ app.wsException(Exception::class.java) { e, ctx ->
 HTTP Error mapping is similar to exception mapping, but it operates on HTTP status codes instead of Exceptions:
 {% capture java %}
 app.error(404, ctx -> {
-    ctx.result("Generic 404 message")
+    ctx.result("Generic 404 message");
 });
 {% endcapture %}
 {% capture kotlin %}
@@ -986,7 +986,7 @@ It can make sense to use them together:
 app.exception(FileNotFoundException.class, (e, ctx) -> {
     ctx.status(404);
 }).error(404, ctx -> {
-    ctx.result("Generic 404 message")
+    ctx.result("Generic 404 message");
 });
 {% endcapture %}
 {% capture kotlin %}
@@ -1002,7 +1002,7 @@ You can also include the content type when declaring your error mappers:
 
 {% capture java %}
 app.error(404, "html", ctx -> {
-    ctx.html("Generic 404 message")
+    ctx.html("Generic 404 message");
 });
 {% endcapture %}
 {% capture kotlin %}

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -1001,7 +1001,7 @@ app.exception(FileNotFoundException::class.java) { e, ctx ->
 You can also include the content type when declaring your error mappers:
 
 {% capture java %}
-app.error(404, "html" ctx -> {
+app.error(404, "html", ctx -> {
     ctx.html("Generic 404 message")
 });
 {% endcapture %}


### PR DESCRIPTION
Hey folks,

I read the documentation about error mapping of status codes and saw that some symbols are missing. I just added them really fast and created this PR. 

Thank you very much for the work on javalin! 

Have a great day! :)