### PR TITLE
Use Ubuntu 24.04 for Github Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
   # Build job
   build:
     if: github.repository == 'javalin/website'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/pr-previews.yml
+++ b/.github/workflows/pr-previews.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   Deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event.action != 'closed' }}
     steps: 
       - name: Create the comment to be updated
@@ -80,7 +80,7 @@ jobs:
             | 🔍 Latest deploy log | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |
 
   Teardown:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event.action == 'closed' }}
     steps:
       - name: Install surge


### PR DESCRIPTION
My other pr failed because Ubuntu 20.04 is no longer supported on the hosted GitHub action runners.
This PR switches to the newest LTS Version 22.04